### PR TITLE
Added unique prop

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -73,9 +73,12 @@ const upload = function (
               resData["data"] = await Deno.readFile(resData["tempfile"]);
             }
             if (saveFile) {
-              const d = new Date();
-              const uuid = `${d.getFullYear()}\\${d.getMonth() +
-                1}\\${d.getDate()}\\${d.getHours()}\\${d.getMinutes()}\\${d.getSeconds()}\\${v4.generate()}`; //TODO improve to use of v5
+              let uuid : String;
+              if(addUuid){
+                const d = new Date();
+                uuid=`${d.getFullYear()}\\${d.getMonth() +
+                  1}\\${d.getDate()}\\${d.getHours()}\\${d.getMinutes()}\\${d.getSeconds()}\\${v4.generate()}`
+              } //TODO improve to use of v5
               const uploadPath = `${path}${addUuid ? `\\${uuid}` : ''}`;
               let fullPath = uploadPath;
               if (useCurrentDir) {


### PR DESCRIPTION
Sometimes I want that dummy folders (2020/8/2/20/4...) not to be created but file to be unique.
This is new feature `unique`. If unique is set to true, dummy folders won't be created but file name will always be unique to avoid internal server errors that is caused by two files with same name.