### PR TITLE
Make date sub dir optional and use deno optional parameters style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This middleware automatically organizes uploads to avoid file system problems an
 Ex: 
 ```javascript
 .post("/upload", upload('uploads'), async (context: any, next: any) => { ...
-.post("/upload", upload('uploads', ['jpg','png'], 20000000, 10000000, true, false, true), async (context: any, next: any) => { ...
+.post("/upload", upload('uploads', { extensions: ['jpg', 'png'], maxSizeBytes: 20000000, maxFileSizeBytes: 10000000, saveFile: true, readFile: false, useCurrentDir: true, useDateTimeSubDir: true }), async (context: any, next: any) => { ...
+.post("/upload", upload('uploads', { extensions: ['jpg', 'png'], useDateTimeSubDir: false }), async (context: any, next: any) => { ...
 ```
 Uploads will be in <b>context.uploadedFiles</b>;
 
@@ -24,6 +25,8 @@ Uploads will be in <b>context.uploadedFiles</b>;
 <b>readFile</b>: optional, if true the file will be fully loaded on the ram and a Uint8Array will be returned in the 'data' field, default false.
 
 <b>useCurrentDir</b>: optional, if true the path is relative to current Deno working directory, default true.
+
+<b>useDateTimeSubDir</b>: optional, if true the file path will be prefixed with /year/month/day/hour/minute/second/uuid/filename e.g. `/2020/4/4/20/0/28/1350065e-7053-429b-869b-08008a098b23/test.jpg`, default true.
 
 <b>)</b>, next middlewares ...
 
@@ -82,7 +85,7 @@ In Deno:
 ```javascript
 import { upload, preUploadValidate} from "https://deno.land/x/upload_middleware_for_oak_framework/mod.ts";
 
-  .post("/upload", upload('uploads', ['jpg','png'], 20000000, 10000000, true, false, true),
+  .post("/upload", upload('uploads', { extensions: ['jpg', 'png'], maxSizeBytes: 20000000, maxFileSizeBytes: 10000000 }),
     async (context: any, next: any) => {
       context.response.body = context.uploadedFiles;
     },

--- a/mod.ts
+++ b/mod.ts
@@ -8,7 +8,7 @@ interface UploadOptions {
   saveFile?: boolean;
   readFile?: boolean;
   useCurrentDir?: boolean;
-  useDateTimeSubFolders?: boolean;
+  useDateTimeSubDir?: boolean;
 }
 
 const defaultUploadOptions: UploadOptions = {
@@ -18,7 +18,7 @@ const defaultUploadOptions: UploadOptions = {
   saveFile: true,
   readFile: false,
   useCurrentDir: true,
-  useDateTimeSubFolders: true,
+  useDateTimeSubDir: true,
 }
 
 const upload = function (
@@ -26,7 +26,7 @@ const upload = function (
   options: UploadOptions = defaultUploadOptions
 ) {
   const mergedOptions = Object.assign({}, defaultUploadOptions, options);
-  const { extensions, maxSizeBytes, maxFileSizeBytes, saveFile, readFile, useCurrentDir, useDateTimeSubFolders } = mergedOptions;
+  const { extensions, maxSizeBytes, maxFileSizeBytes, saveFile, readFile, useCurrentDir, useDateTimeSubDir } = mergedOptions;
   ensureDirSync(join(Deno.cwd(), 'temp_uploads'));
   return async (context: any, next: any) => {
     if (
@@ -92,7 +92,7 @@ const upload = function (
             if (saveFile) {
               let uploadPath = path;
               let uuid = '';
-              if (useDateTimeSubFolders) {
+              if (useDateTimeSubDir) {
                 const d = new Date();
                 uuid = join(
                   d.getFullYear().toString(),

--- a/mod.ts
+++ b/mod.ts
@@ -1,19 +1,36 @@
 import { ensureDir, ensureDirSync, v4, move, MultipartReader } from "./deps.ts";
 import { SEP, join } from "https://deno.land/std/path/mod.ts";
 
+interface UploadOptions {
+  extensions?: Array<string>;
+  maxSizeBytes?: number;
+  maxFileSizeBytes?: number;
+  saveFile?: boolean;
+  readFile?: boolean;
+  useCurrentDir?: boolean;
+  useDateTimeSubFolders?: boolean;
+}
+
+const defaultUploadOptions: UploadOptions = {
+  extensions: [],
+  maxSizeBytes: Number.MAX_SAFE_INTEGER,
+  maxFileSizeBytes: Number.MAX_SAFE_INTEGER,
+  saveFile: true,
+  readFile: false,
+  useCurrentDir: true,
+  useDateTimeSubFolders: true,
+}
+
 const upload = function (
   path: string,
-  extensions: Array<string> = [],
-  maxSizeBytes: number = Number.MAX_SAFE_INTEGER,
-  maxFileSizeBytes: number = Number.MAX_SAFE_INTEGER,
-  saveFile: boolean = true,
-  readFile: boolean = false,
-  useCurrentDir: boolean = true,
+  options: UploadOptions = defaultUploadOptions
 ) {
+  const mergedOptions = Object.assign({}, defaultUploadOptions, options);
+  const { extensions, maxSizeBytes, maxFileSizeBytes, saveFile, readFile, useCurrentDir, useDateTimeSubFolders } = mergedOptions;
   ensureDirSync(join(Deno.cwd(), 'temp_uploads'));
   return async (context: any, next: any) => {
     if (
-      parseInt(context.request.headers.get("content-length")) > maxSizeBytes
+      parseInt(context.request.headers.get("content-length")) > maxSizeBytes!
     ) {
       context.throw(
         422,
@@ -44,14 +61,14 @@ const upload = function (
         let values: any = [].concat(item[1]);
         for (const val of values) {
           if (val.filename !== undefined) {
-            if (extensions.length > 0) {
+            if (extensions!.length > 0) {
               let ext = val.filename.split(".").pop();
-              if (!extensions.includes(ext)) {
+              if (!extensions!.includes(ext)) {
                 validations +=
                   `The file extension is not allowed (${ext} in ${val.filename}), allowed extensions: ${extensions}. `;
               }
             }
-            if (val.size > maxFileSizeBytes) {
+            if (val.size > maxFileSizeBytes!) {
               validations +=
                 `Maximum file upload size exceeded, file: ${val.filename}, size: ${val.size} bytes, maximum: ${maxFileSizeBytes} bytes. `;
             }
@@ -73,17 +90,21 @@ const upload = function (
               resData["data"] = await Deno.readFile(resData["tempfile"]);
             }
             if (saveFile) {
-              const d = new Date();
-              const uuid = join(
-                d.getFullYear().toString(),
-                (d.getMonth()+1).toString(),
-                d.getDate().toString(),
-                d.getHours().toString(),
-                d.getMinutes().toString(),
-                d.getSeconds().toString(),
-                v4.generate() //TODO improve to use of v5
-              );
-              const uploadPath = join(path,uuid);
+              let uploadPath = path;
+              let uuid = '';
+              if (useDateTimeSubFolders) {
+                const d = new Date();
+                uuid = join(
+                  d.getFullYear().toString(),
+                  (d.getMonth()+1).toString(),
+                  d.getDate().toString(),
+                  d.getHours().toString(),
+                  d.getMinutes().toString(),
+                  d.getSeconds().toString(),
+                  v4.generate() //TODO improve to use of v5
+                );
+                uploadPath = join(path,uuid);
+              };
               let fullPath = uploadPath;
               if (useCurrentDir) {
                 fullPath = join(Deno.cwd(),fullPath);


### PR DESCRIPTION
Give user more control on module path creation.
Be compliant w/ deno style guide https://deno.land/manual/contributing/style_guide#exported-functions-max-2-args-put-the-rest-into-an-options-object 